### PR TITLE
Minor patch over v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.2] - 2021-12-07
 
 ### Changed
 - Entity `ProductCategory` and Path `/data/product_categories`
   - property & query parameter `code` changed from type `integer` to `string`
   - query parameter `parentCode` changed from type `integer` to `string`
+- All GET resources within `/data` include pagination parameters `pageIndex`, `pageSize`, `sortBy`, `sortOrder`
 
 ## [1.1.1] - 2021-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Entity `ProductCategory` and Path `/data/product_categories`
   - property & query parameter `code` changed from type `integer` to `string`
+  - query parameter `parentCode` changed from type `integer` to `string`
 
 ## [1.1.1] - 2021-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Entity `ProductCategory` and Path `/data/product_categories`
+  - property & query parameter `code` changed from type `integer` to `string`
+
 ## [1.1.1] - 2021-10-24
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Trébol eCommerce API
+    Copyright (C) 2021 The Trébol eCommerce Project
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    Trébol eCommerce API Copyright (C) 2021 The Trébol eCommerce Project
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,47 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-Declares the resources that instances of the Trébol backend must expose. Involves working with internal data, user accounts, public information, etc... [The documentation can be found here.](https://studio-ws.apicur.io/sharing/b0bc9a13-4e93-4be2-8636-108986e75ce4)
+Declares the resources that instances of the Trébol backend must expose. [Review the documentation here.](https://studio-ws.apicur.io/sharing/b0bc9a13-4e93-4be2-8636-108986e75ce4)
 
 This API has been designed using [APICurio](https://www.apicur.io/), a beautiful web platform and free service made for the job.
+
+## Specification
+
+Below is a short summary of available paths and their purposes. Unless stated otherwise, they all impose the need of a Bearer token auth.
+
+### `/access` - Allowed privileges for the API consumer
+
+- `/` - Lists all paths in `/data` that the API consumer has any level of access to
+- `/{context}` - Lists allowed CRUD operations on a given context. Can contain any combination of these four: `create`, `read`, `update` and `delete`
+
+### `/account` - Resources for the API consumer and their user account
+
+- `/profile` - Fetch or update existing personal and contact information
+
+### `/data` - Execution of CRUD operations for all supported contexts
+
+- `/billing_types` - Options for generating bill receipts
+- `/customers` - Correlation of stored personal information towards clients that have actually requested to purchase through the store
+- `/images` - Metadata of photos and pictures uploaded and served through any internal and/or external web service, assumed to be accesible from the internet
+- `/people` - Stored contact and/or personal information about real-life individuals
+- `/product_categories` - Tree-like schema of organization for products
+- `/products` - The items that the store displays to the public and makes available for purchase. Includes products not available for purchase
+- `/sales` - The purchases acknowledged through the store; they follow a certain transaction flow; updating their state to `requested`, `paid`, `cancelled`, `failed`, `delivered`, among others
+- `/salespeople` - Correlation of stored personal information towards employees that earn sales through the store
+- `/shippers` - Metadata of internal and/or external logistics services for shipping and delivery of physical items
+- `/user_roles` - Metadata of available privilege groupings for users
+- `/users` - Metadata of available accounts to access API resources
+
+### `/public` - API resources that may not require auth
+
+- `/about` - Metadata about the store and their respective owners
+- `/checkout` - (Needs auth) Transaction request; where consumers submit a cart with products and receive details to be redirected to the payment page.
+  - `/validate` - Endpoint of return from payment page. Must redirect to a result page served through the corresponding frontend of the store.
+- `/guest` - Request a short-lived auth token that can be used for calls to `/checkout`
+- `/login` - Request for authentication with an existing user account, and generation + fetching of new auth token
+- `/products` - Similar to `/data/products`, but will only fetch products available to the public
+- `/receipt/{code}` - Metadata for a specific `Sell`. The `code` variable must identify only one transaction, but its exact meaning can vary
+- `/register` - Request for creation of a new user account
 
 ## Contributors ✨
 

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -1916,7 +1916,7 @@
                 }
             ]
         },
-        "/data/products/{code}": {
+        "/data/products/{barcode}": {
             "summary": "Specific-product API endpoint",
             "get": {
                 "tags": [
@@ -2010,7 +2010,7 @@
             },
             "parameters": [
                 {
-                    "name": "code",
+                    "name": "barcode",
                     "description": "A unique code for a Product.",
                     "schema": {
                         "type": "integer"

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -2013,7 +2013,7 @@
                     "name": "barcode",
                     "description": "A unique code for a Product.",
                     "schema": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "in": "path",
                     "required": true
@@ -2985,7 +2985,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/User"
+                                "$ref": "#/components/schemas/Shipper"
                             }
                         }
                     },
@@ -3018,7 +3018,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/User"
+                                "$ref": "#/components/schemas/Shipper"
                             }
                         }
                     },
@@ -3080,6 +3080,14 @@
                 {
                     "name": "name",
                     "description": "The exact name of the shipper. Case sensitive.",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "in": "query"
+                },
+                {
+                    "name": "nameLike",
+                    "description": "A portion of the shipper's name. Case insensitive.",
                     "schema": {
                         "type": "string"
                     },

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Trébol API",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "description": "A collection of resources that the Trébol backend exposes to interact with.",
         "contact": {
             "name": "Benjamin La Madrid",
@@ -2150,7 +2150,7 @@
                     "name": "code",
                     "description": "The code of the category.\nWhen specified, rules out all other query parameters.",
                     "schema": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "in": "query"
                 },
@@ -3753,7 +3753,8 @@
                 "title": "Root Type for ProductFamily",
                 "description": "A Product group/category. Each one can be divided into smaller subsets (ProductType).",
                 "required": [
-                    "name"
+                    "name",
+                    "code"
                 ],
                 "type": "object",
                 "properties": {
@@ -3767,7 +3768,7 @@
                     },
                     "code": {
                         "description": "A unique identifier for the category.",
-                        "type": "integer"
+                        "type": "string"
                     }
                 },
                 "example": {

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -170,7 +170,7 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of customers per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
@@ -178,7 +178,7 @@
                     },
                     {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -186,7 +186,7 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "Customer property to sort by",
+                        "description": "Property to sort by",
                         "schema": {
                             "type": "string"
                         },
@@ -194,7 +194,7 @@
                     },
                     {
                         "name": "order",
-                        "description": "Sort order (ascending or descending)",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -368,31 +368,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of people per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "People sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -400,7 +384,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "People property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -444,31 +436,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of products per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "Product sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -476,7 +452,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "Product property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -653,31 +637,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of sales per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "Sell sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -685,7 +653,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "Sell property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -831,31 +807,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of users per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "User sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -863,7 +823,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "User property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -1016,18 +984,33 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of images per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
-                        "in": "query",
-                        "required": false
+                        "in": "query"
                     },
                     {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "sortBy",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
+                        "schema": {
+                            "type": "string"
                         },
                         "in": "query"
                     }
@@ -2720,31 +2703,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of salespeople per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "Salesperson sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -2752,7 +2719,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "Salesperson property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },
@@ -2929,31 +2904,15 @@
                 "parameters": [
                     {
                         "name": "pageSize",
-                        "description": "Number of users per page",
+                        "description": "Expected maximum number of items per page",
                         "schema": {
                             "type": "integer"
                         },
                         "in": "query"
                     },
                     {
-                        "examples": {
-                            "Ascending order": {
-                                "value": "\"asc\""
-                            },
-                            "Descending order": {
-                                "value": "\"desc\""
-                            }
-                        },
-                        "name": "order",
-                        "description": "User sort order (ascending or descending)",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
                         "name": "pageIndex",
-                        "description": "Index of page (0-based)",
+                        "description": "0-based index of page",
                         "schema": {
                             "type": "integer"
                         },
@@ -2961,7 +2920,15 @@
                     },
                     {
                         "name": "sortBy",
-                        "description": "User property to sort by",
+                        "description": "Property to sort by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "name": "order",
+                        "description": "Sort order (ascending/descending)",
                         "schema": {
                             "type": "string"
                         },

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -2141,7 +2141,7 @@
                     "name": "parentCode",
                     "description": "The code of a parent category. If left empty, no exclusions are made.\n\nValid numbers exclude root categories.\n`null` makes it so only root categories are included.",
                     "schema": {
-                        "type": "integer"
+                        "type": "string"
                     },
                     "in": "query",
                     "required": false


### PR DESCRIPTION
This PR will update data type for product categories `code`, which was an alias for the underlying `id` number property. Instead, `code` should be a string, and should allow only simple characters (alphanumeric, dashes and underlines). 

The expected result is that when making API calls using said code, such as `/product_categories?code=XSM_CARE12V`, the URL remains somewhat readable, without using encoded chars for white-spaces and so on.

In addition to this, some minor incongruities in the spec were addressed, too. And the README file now gives some insight on the overall features and purposes of this API.

Also, resolve #44