### PR TITLE
Split part of the API components [v1.6.0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+# worktree files
+gitdir
+commondir
+HEAD
+index
+index.lock
+ORIG_HEAD
+COMMIT_EDITMSG
+logs/
+REBASE_HEAD
+FETCH_HEAD
+rebase-merge/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.6.0] - 2023-03-29
+## [v1.6.0] - 2023-04-10
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.6.0] - 2023-03-29
+
+### Changed
+
+- Created a second API document `common.trebol-api.json` for common components
+  - Moved schemas to this document
+    - `DataPage`
+    - `LoginCredentials`
+    - `UserRegistration`
+    - `AuthorizedAccess`
+    - `Person`
+  - Moved responses to this document
+    - `PaginatedCollection`
+    - `Forbidden`
+    - `AuthorizedAccessToResource`
+    - `AuthorizedAccessToRoutes`
+    - `NotFound`
+    - `Empty`
+    - `AllowMethodPOST`
+    - `AllowMethodGET`
+    - `AllowAllMethods`
+    - `AllowMethodGET-PUT`
+    - `BadRequestBody`
+  - Rewritten References (`$ref`) to load all these components from the second document file if it exists in the same directory
+
 ## [v1.5.4] - 2023-03-27
 
 ### Changed

--- a/common.trebol-api.json
+++ b/common.trebol-api.json
@@ -1,0 +1,244 @@
+{
+    "info": {
+        "title": "Trébol API Commons",
+        "version": "1.0.0",
+        "description": "A collection of components for reusing in other API documents.",
+        "contact": {
+            "name": "Benjamin La Madrid",
+            "email": "bg.lamadrid@gmail.com"
+        },
+        "license": {
+            "name": "GNU GPLv3",
+            "url": "https://www.gnu.org/licenses/gpl.txt"
+        }
+    },
+    "components": {
+        "schemas": {
+            "DataPage": {
+                "title": "Root Type for DataPage",
+                "description": "A pageable representation of data.",
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "description": "The contents of the page.",
+                        "type": "array",
+                        "items": {}
+                    },
+                    "pageIndex": {
+                        "description": "The index of the page (0-based)",
+                        "type": "integer"
+                    },
+                    "totalCount": {
+                        "description": "The total amount of items matched under the same search criteria.",
+                        "type": "integer"
+                    },
+                    "pageSize": {
+                        "description": "The amount of items that any page may have.",
+                        "type": "integer"
+                    }
+                },
+                "example": {
+                    "items": [
+                        {
+                            "name": "example product",
+                            "code": "EXMPL001"
+                        },
+                        {
+                            "name": "example product 2",
+                            "code": "EXMPL002"
+                        }
+                    ],
+                    "pageIndex": 2,
+                    "totalCount": 32,
+                    "pageSize": 15
+                }
+            },
+            "LoginCredentials": {
+                "title": "Root Type for LoginCredentials",
+                "description": "Data sent by an user to authenticate themselves.",
+                "required": [
+                    "name",
+                    "password"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The user name.",
+                        "type": "string"
+                    },
+                    "password": {
+                        "description": "The user password.",
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "name": "an username",
+                    "password": "a password"
+                }
+            },
+            "UserRegistration": {
+                "title": "Root Type for UserRegistration",
+                "description": "Credentials and personal information for a new user account.",
+                "required": [
+                    "password",
+                    "profile",
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "password": {
+                        "type": "string"
+                    },
+                    "profile": {
+                        "$ref": "#/components/schemas/Person"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "password": "some text",
+                    "profile": {
+                        "name": "some text",
+                        "idNumber": "some text",
+                        "email": "some text",
+                        "phone1": "+1111111111",
+                        "phone2": "+22 222 222 22"
+                    },
+                    "name": "some text"
+                }
+            },
+            "AuthorizedAccess": {
+                "title": "Root Type for AuthorizedAcess",
+                "description": "A generic container of API resource paths or actions on a specific resource, for which access is granted",
+                "type": "object",
+                "properties": {
+                    "routes": {
+                        "description": "A list of authorized routes to consume.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "permissions": {
+                        "description": "A list of authorized actions for a specific route.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "example": {
+                    "routes": [
+                        "clients",
+                        "products",
+                        "people",
+                        "sales",
+                        "salespeople",
+                        "users"
+                    ]
+                }
+            },
+            "Person": {
+                "title": "Root Type for Person",
+                "description": "Personal information about an individual.",
+                "required": [
+                    "idNumber"
+                ],
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "description": "The e-mail address.",
+                        "type": "string"
+                    },
+                    "phone1": {
+                        "description": "The preferred personal phone number",
+                        "pattern": "^(\\(\\+?(\\d{3}|\\d{2} ?\\d)\\)|\\+?\\d{3}|\\+?\\d{2}[ -]?\\d)?[ -]?(\\d{8}|(\\d{2,4}[ -]?){2,4}|)$",
+                        "type": "string"
+                    },
+                    "phone2": {
+                        "description": "A second phone number",
+                        "pattern": "^(\\(\\+?(\\d{3}|\\d{2} ?\\d)\\)|\\+?\\d{3}|\\+?\\d{2}[ -]?\\d)?[ -]?(\\d{8}|(\\d{2,4}[ -]?){2,4}|)$",
+                        "type": "string"
+                    },
+                    "idNumber": {
+                        "description": "The national identification number as issued by the individual's birth country government.",
+                        "type": "string"
+                    },
+                    "firstName": {
+                        "description": "The individual's first name.",
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "description": "The individual's last or family name.",
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "firstName": "Isaac Sebastian",
+                    "lastName": "Williams McGregor",
+                    "idNumber": "123456789-0",
+                    "email": "example@email.com",
+                    "phone1": "(+512)784 876 823",
+                    "phone2": "4444 9820"
+                }
+            }
+        },
+        "responses": {
+            "PaginatedCollection": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/DataPage"
+                        }
+                    }
+                },
+                "description": "Normal response for most \"/data\" methods; sends items in an array, along with pagination metadata."
+            },
+            "Forbidden": {
+                "description": "Erroneous, empty response for requests not meeting security requirements. Most likely, it does not have authorization to access specific privileged resource(s), or does not include any form of authentication while requesting some privileged resource(s)."
+            },
+            "AuthorizedAccessToResource": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/AuthorizedAccess"
+                        }
+                    }
+                },
+                "description": "Normal response. Sends an AuthorizedAccess object with an array of available and permitted actions."
+            },
+            "AuthorizedAccessToRoutes": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/AuthorizedAccess"
+                        }
+                    }
+                },
+                "description": "Normal response. Sends an array of API routes available for use from a parent path."
+            },
+            "NotFound": {
+                "description": "Non-erroneous, empty response which indicates that no data matched the provided criteria."
+            },
+            "Empty": {
+                "description": "Normal response which indicates everything went right (after successfully altering data, for example) and that there's no additional information to be included."
+            },
+            "AllowMethodPOST": {
+                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the POST method is allowed."
+            },
+            "AllowMethodGET": {
+                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the GET method is allowed."
+            },
+            "AllowAllMethods": {
+                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that the methods GET, POST PUT and DELETE are allowed."
+            },
+            "AllowMethodGET-PUT": {
+                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the GET and PUT methods are allowed."
+            },
+            "BadRequestBody": {
+                "description": "Erroneous response, sent when the request does not meet certain expectations. This probably because required properties were not included in the request body, or because certain data constraints (duplicate code numbers, for example) were not met."
+            }
+        }
+    }
+}

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -94,10 +94,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AuthorizedAccessToRoutes"
+                        "$ref": "common.trebol-api.json#/components/responses/AuthorizedAccessToRoutes"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -115,7 +115,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "security": [
@@ -135,10 +135,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AuthorizedAccessToResource"
+                        "$ref": "common.trebol-api.json#/components/responses/AuthorizedAccessToResource"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -156,7 +156,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "operationId": "access-resource-options",

--- a/trebol-api.json
+++ b/trebol-api.json
@@ -2,8 +2,8 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Trébol eCommerce API",
-        "version": "1.5.4",
-        "description": "A collection of resources that the Trébol backend exposes to interact with.",
+        "version": "1.6.0",
+        "description": "A collection of resources that the Trébol backend exposes to interact with. Depends on, and references `Trébol eCommerce API Commons v1.0.0`",
         "contact": {
             "name": "Benjamin La Madrid",
             "email": "bg.lamadrid@gmail.com"
@@ -226,10 +226,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -258,16 +258,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -296,13 +296,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -321,13 +321,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -345,7 +345,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-customers-options",
@@ -455,10 +455,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -476,7 +476,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "operationId": "access-people-options",
@@ -536,7 +536,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     }
                 },
                 "operationId": "data-products-get",
@@ -560,16 +560,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -598,13 +598,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -623,13 +623,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -647,7 +647,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-products-options",
@@ -792,10 +792,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -824,16 +824,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -862,13 +862,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -887,13 +887,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -911,7 +911,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-sales-options",
@@ -948,10 +948,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -969,7 +969,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "operationId": "data-sales-confirmation-options",
@@ -996,10 +996,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1017,7 +1017,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "operationId": "data-sales-rejection-options",
@@ -1044,10 +1044,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1065,7 +1065,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "operationId": "data-sales-completion-options",
@@ -1126,10 +1126,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1158,16 +1158,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1196,13 +1196,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1221,13 +1221,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1245,7 +1245,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "security": [
@@ -1334,10 +1334,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1366,16 +1366,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1404,13 +1404,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1429,13 +1429,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1453,7 +1453,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "security": [
@@ -1487,7 +1487,7 @@
                         }
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1505,7 +1505,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "security": [
@@ -1548,7 +1548,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "security": [
@@ -1606,10 +1606,10 @@
                         "description": "Normal response. The transaction was acknowledged and initiated. Details to redirect towards the payment page are included."
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1627,7 +1627,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "security": [
@@ -1649,10 +1649,10 @@
                         "description": "Normal, empty response, sent when the transaction was approved. Redirects the user.\n\n'Location' response header should be included with a URL to the result page."
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1668,7 +1668,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "security": [
@@ -1697,7 +1697,7 @@
                         }
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1713,7 +1713,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "security": [
@@ -1782,16 +1782,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1820,13 +1820,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1845,13 +1845,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -1869,7 +1869,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "security": [
@@ -1929,13 +1929,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Person"
+                                    "$ref": "common.trebol-api.json#/components/schemas/Person"
                                 }
                             }
                         }
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1952,7 +1952,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Person"
+                                "$ref": "common.trebol-api.json#/components/schemas/Person"
                             }
                         }
                     },
@@ -1964,13 +1964,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -1988,7 +1988,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET-PUT"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET-PUT"
                     }
                 },
                 "security": [
@@ -2007,7 +2007,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/Person"
+                                "$ref": "common.trebol-api.json#/components/schemas/Person"
                             }
                         }
                     },
@@ -2038,7 +2038,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "security": [
@@ -2087,7 +2087,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "security": [
@@ -2105,7 +2105,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRegistration"
+                                "$ref": "#auth.trebol-api.json/components/schemas/UserRegistration"
                             }
                         }
                     },
@@ -2116,10 +2116,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     }
                 },
                 "security": [
@@ -2135,7 +2135,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodPOST"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodPOST"
                     }
                 },
                 "security": [
@@ -2182,7 +2182,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowMethodGET"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowMethodGET"
                     }
                 },
                 "security": [
@@ -2245,10 +2245,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -2277,16 +2277,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2315,13 +2315,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -2340,13 +2340,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2364,7 +2364,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "security": [
@@ -2477,7 +2477,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     }
                 },
                 "security": [
@@ -2504,16 +2504,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2542,13 +2542,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -2567,13 +2567,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2591,7 +2591,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-shippers-options",
@@ -2735,16 +2735,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2773,13 +2773,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -2798,13 +2798,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2822,7 +2822,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-product-lists-options",
@@ -2932,7 +2932,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/PaginatedCollection"
+                        "$ref": "common.trebol-api.json#/components/responses/PaginatedCollection"
                     }
                 },
                 "operationId": "data-product-list-contents-get",
@@ -2959,16 +2959,16 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -2997,13 +2997,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "400": {
-                        "$ref": "#/components/responses/BadRequestBody"
+                        "$ref": "common.trebol-api.json#/components/responses/BadRequestBody"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     }
                 },
                 "security": [
@@ -3048,13 +3048,13 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/Empty"
+                        "$ref": "common.trebol-api.json#/components/responses/Empty"
                     },
                     "403": {
-                        "$ref": "#/components/responses/Forbidden"
+                        "$ref": "common.trebol-api.json#/components/responses/Forbidden"
                     },
                     "404": {
-                        "$ref": "#/components/responses/NotFound"
+                        "$ref": "common.trebol-api.json#/components/responses/NotFound"
                     }
                 },
                 "security": [
@@ -3072,7 +3072,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/AllowAllMethods"
+                        "$ref": "common.trebol-api.json#/components/responses/AllowAllMethods"
                     }
                 },
                 "operationId": "data-product-list-contents-options",
@@ -3115,82 +3115,6 @@
                 "example": {
                     "name": "an username",
                     "password": "a password"
-                }
-            },
-            "Person": {
-                "title": "Root Type for Person",
-                "description": "Personal information about an individual.",
-                "required": [
-                    "idNumber"
-                ],
-                "type": "object",
-                "properties": {
-                    "email": {
-                        "description": "The e-mail address.",
-                        "type": "string"
-                    },
-                    "phone1": {
-                        "description": "The preferred personal phone number",
-                        "pattern": "^(\\(\\+?(\\d{3}|\\d{2} ?\\d)\\)|\\+?\\d{3}|\\+?\\d{2}[ -]?\\d)?[ -]?(\\d{8}|(\\d{2,4}[ -]?){2,4}|)$",
-                        "type": "string"
-                    },
-                    "phone2": {
-                        "description": "A second phone number",
-                        "pattern": "^(\\(\\+?(\\d{3}|\\d{2} ?\\d)\\)|\\+?\\d{3}|\\+?\\d{2}[ -]?\\d)?[ -]?(\\d{8}|(\\d{2,4}[ -]?){2,4}|)$",
-                        "type": "string"
-                    },
-                    "idNumber": {
-                        "description": "The national identification number as issued by the individual's birth country government.",
-                        "type": "string"
-                    },
-                    "firstName": {
-                        "description": "The individual's first name.",
-                        "type": "string"
-                    },
-                    "lastName": {
-                        "description": "The individual's last or family name.",
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "firstName": "Isaac Sebastian",
-                    "lastName": "Williams McGregor",
-                    "idNumber": "123456789-0",
-                    "email": "example@email.com",
-                    "phone1": "(+512)784 876 823",
-                    "phone2": "4444 9820"
-                }
-            },
-            "UserRegistration": {
-                "title": "Root Type for UserRegistration",
-                "description": "Credentials and personal information for a new user account.",
-                "required": [
-                    "password",
-                    "profile",
-                    "name"
-                ],
-                "type": "object",
-                "properties": {
-                    "password": {
-                        "type": "string"
-                    },
-                    "profile": {
-                        "$ref": "#/components/schemas/Person"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "password": "some text",
-                    "profile": {
-                        "name": "some text",
-                        "idNumber": "some text",
-                        "email": "some text",
-                        "phone1": "+1111111111",
-                        "phone2": "+22 222 222 22"
-                    },
-                    "name": "some text"
                 }
             },
             "CartDetail": {
@@ -3465,7 +3389,7 @@
                 "type": "object",
                 "properties": {
                     "person": {
-                        "$ref": "#/components/schemas/Person"
+                        "$ref": "common.trebol-api.json#/components/schemas/Person"
                     }
                 },
                 "example": {
@@ -3487,7 +3411,7 @@
                 "type": "object",
                 "properties": {
                     "person": {
-                        "$ref": "#/components/schemas/Person"
+                        "$ref": "common.trebol-api.json#/components/schemas/Person"
                     }
                 },
                 "example": {
@@ -3674,7 +3598,7 @@
                         "type": "string"
                     },
                     "person": {
-                        "$ref": "#/components/schemas/Person"
+                        "$ref": "common.trebol-api.json#/components/schemas/Person"
                     },
                     "role": {
                         "description": "The name of the role this user has.",
@@ -3760,44 +3684,6 @@
                 "example": {
                     "code": 1,
                     "name": "example category"
-                }
-            },
-            "DataPage": {
-                "description": "A pageable representation of data.",
-                "type": "object",
-                "properties": {
-                    "items": {
-                        "description": "The contents of the page.",
-                        "type": "array",
-                        "items": {}
-                    },
-                    "pageIndex": {
-                        "description": "The index of the page (0-based)",
-                        "type": "integer"
-                    },
-                    "totalCount": {
-                        "description": "The total amount of items matched under the same search criteria used to fetch the current page.",
-                        "type": "integer"
-                    },
-                    "pageSize": {
-                        "description": "The amount of items requested and (presumably) contained in the page.",
-                        "type": "integer"
-                    }
-                },
-                "example": {
-                    "items": [
-                        {
-                            "name": "example product",
-                            "code": "EXMPL001"
-                        },
-                        {
-                            "name": "example product 2",
-                            "code": "EXMPL002"
-                        }
-                    ],
-                    "pageIndex": 2,
-                    "totalCount": 32,
-                    "pageSize": 15
                 }
             },
             "Address": {
@@ -3937,62 +3823,6 @@
                     "totalCount": 32,
                     "pageSize": 15
                 }
-            }
-        },
-        "responses": {
-            "PaginatedCollection": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/DataPage"
-                        }
-                    }
-                },
-                "description": "Normal response for most \"/data\" methods; sends items in an array, along with pagination metadata."
-            },
-            "Forbidden": {
-                "description": "Erroneous, empty response for requests not meeting security requirements. Most likely, it does not have authorization to access specific privileged resource(s), or does not include any form of authentication while requesting some privileged resource(s)."
-            },
-            "AuthorizedAccessToResource": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/AuthorizedAccess"
-                        }
-                    }
-                },
-                "description": "Normal response. Sends an AuthorizedAccess object with an array of available and permitted actions."
-            },
-            "AuthorizedAccessToRoutes": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/AuthorizedAccess"
-                        }
-                    }
-                },
-                "description": "Normal response. Sends an array of API routes available for use from a parent path."
-            },
-            "NotFound": {
-                "description": "Non-erroneous, empty response which indicates that no data matched the provided criteria."
-            },
-            "Empty": {
-                "description": "Normal response which indicates everything went right (after successfully altering data, for example) and that there's no additional information to be included."
-            },
-            "AllowMethodPOST": {
-                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the POST method is allowed."
-            },
-            "AllowMethodGET": {
-                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the GET method is allowed."
-            },
-            "AllowAllMethods": {
-                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that the methods GET, POST PUT and DELETE are allowed."
-            },
-            "AllowMethodGET-PUT": {
-                "description": "Normal, empty response to some OPTIONS requests. Should include CORS headers and indicate that only the GET and PUT methods are allowed."
-            },
-            "BadRequestBody": {
-                "description": "Erroneous response, sent when the request does not meet certain expectations. This probably because required properties were not included in the request body, or because certain data constraints (duplicate code numbers, for example) were not met."
             }
         },
         "securitySchemes": {


### PR DESCRIPTION
### Changed

- Created a second API document `common.trebol-api.json` for common components
  - Moved schemas to this document
    - `DataPage`
    - `LoginCredentials`
    - `UserRegistration`
    - `AuthorizedAccess`
    - `Person`
  - Moved responses to this document
    - `PaginatedCollection`
    - `Forbidden`
    - `AuthorizedAccessToResource`
    - `AuthorizedAccessToRoutes`
    - `NotFound`
    - `Empty`
    - `AllowMethodPOST`
    - `AllowMethodGET`
    - `AllowAllMethods`
    - `AllowMethodGET-PUT`
    - `BadRequestBody`
  - Rewritten References (`$ref`) to load all these components from the second document file if it exists in the same directory