### PR TITLE
feat(build): add `documentation` workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,32 @@
+name: Regenerate and deploy documentation
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+jobs:
+  generate_deploy_documentation:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.5
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install redocly and generate the static site
+        run: |
+          npm i -g @redocly/cli
+          mkdir docs/
+          redocly build-docs src/trebol-api.json --output=docs/index.html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
when the API is pushed to `main`,
this workflow should use Redoc to generate static documentation and deploy it to GitHub Pages